### PR TITLE
Updated Javascript for computing SHA1 hash

### DIFF
--- a/src/sha1.js
+++ b/src/sha1.js
@@ -6,36 +6,24 @@
  * Distributed under the BSD License
  * See http://pajhome.org.uk/crypt/md5 for details.
  */
+var hexcase = 0; 
+var b64pad  = "";
 
-var fromCharCode = String.fromCharCode;
-/*
- * Calculate the SHA1 of a raw string
- */
-function rstr_sha1(s)
-{
-  return binb2rstr(binb_sha1(rstr2binb(s), s.length * 8));
-}
-
-/*
- * Convert a raw string to a hex string
- */
 function rstr2hex(input)
 {
+  try { hexcase } catch(e) { hexcase=0; }
+  var hex_tab = hexcase ? "0123456789ABCDEF" : "0123456789abcdef";
   var output = "";
   var x;
-  for(var i in input)
+  for(var i = 0; i < input.length; i++)
   {
     x = input.charCodeAt(i);
-    output += ((x >> 4) & 0x0F).toString(16)
-           +  ( x        & 0x0F).toString(16);
+    output += hex_tab.charAt((x >>> 4) & 0x0F)
+           +  hex_tab.charAt( x        & 0x0F);
   }
   return output;
 }
 
-/*
- * Encode a string as utf-8.
- * For efficiency, this assumes the input is valid utf-16.
- */
 function str2rstr_utf8(input)
 {
   var output = "";
@@ -44,7 +32,6 @@ function str2rstr_utf8(input)
 
   while(++i < input.length)
   {
-    /* Decode utf-16 surrogate pairs */
     x = input.charCodeAt(i);
     y = i + 1 < input.length ? input.charCodeAt(i + 1) : 0;
     if(0xD800 <= x && x <= 0xDBFF && 0xDC00 <= y && y <= 0xDFFF)
@@ -53,58 +40,45 @@ function str2rstr_utf8(input)
       i++;
     }
 
-    /* Encode output as utf-8 */
     if(x <= 0x7F)
-      output += fromCharCode(x);
+      output += String.fromCharCode(x);
     else if(x <= 0x7FF)
-      output += fromCharCode(0xC0 | ((x >> 6 ) & 0x1F),
+      output += String.fromCharCode(0xC0 | ((x >>> 6 ) & 0x1F),
                                     0x80 | ( x         & 0x3F));
     else if(x <= 0xFFFF)
-      output += fromCharCode(0xE0 | ((x >> 12) & 0x0F),
-                                    0x80 | ((x >> 6 ) & 0x3F),
+      output += String.fromCharCode(0xE0 | ((x >>> 12) & 0x0F),
+                                    0x80 | ((x >>> 6 ) & 0x3F),
                                     0x80 | ( x         & 0x3F));
     else if(x <= 0x1FFFFF)
-      output += fromCharCode(0xF0 | ((x >> 18) & 0x07),
-                                    0x80 | ((x >> 12) & 0x3F),
-                                    0x80 | ((x >> 6 ) & 0x3F),
+      output += String.fromCharCode(0xF0 | ((x >>> 18) & 0x07),
+                                    0x80 | ((x >>> 12) & 0x3F),
+                                    0x80 | ((x >>> 6 ) & 0x3F),
                                     0x80 | ( x         & 0x3F));
   }
   return output;
 }
 
-/*
- * Convert a raw string to an array of big-endian words
- * Characters >255 have their high-byte silently ignored.
- */
+function rstr_sha1(s)
+{
+  return binb2rstr(binb_sha1(rstr2binb(s), s.length * 8));
+}
+
 function rstr2binb(input)
 {
-  var output = [];
+  var output = Array(input.length >> 2);
+  for(var i = 0; i < output.length; i++)
+    output[i] = 0;
   for(var i = 0; i < input.length * 8; i += 8)
     output[i>>5] |= (input.charCodeAt(i / 8) & 0xFF) << (24 - i % 32);
   return output;
 }
 
-/*
- * Convert an array of big-endian words to a string
- */
-function binb2rstr(input)
-{
-  var output = "";
-  for(var i = 0; i < input.length * 32; i += 8)
-    output += fromCharCode((input[i>>5] >> (24 - i % 32)) & 0xFF);
-  return output;
-}
-
-/*
- * Calculate the SHA-1 of an array of big-endian words, and a bit length
- */
 function binb_sha1(x, len)
 {
-  /* append padding */
   x[len >> 5] |= 0x80 << (24 - len % 32);
   x[((len + 64 >> 9) << 4) + 15] = len;
 
-  var w = [];
+  var w = Array(80);
   var a =  1732584193;
   var b = -271733879;
   var c = -1732584194;
@@ -138,14 +112,30 @@ function binb_sha1(x, len)
     d = safe_add(d, oldd);
     e = safe_add(e, olde);
   }
-  return [a, b, c, d, e];
+  return Array(a, b, c, d, e);
 
 }
 
-/*
- * Perform the appropriate triplet combination function for the current
- * iteration
- */
+function binb2rstr(input)
+{
+  var output = "";
+  for(var i = 0; i < input.length * 32; i += 8)
+    output += String.fromCharCode((input[i>>5] >>> (24 - i % 32)) & 0xFF);
+  return output;
+}
+
+function safe_add(x, y)
+{
+  var lsw = (x & 0xFFFF) + (y & 0xFFFF);
+  var msw = (x >> 16) + (y >> 16) + (lsw >> 16);
+  return (msw << 16) | (lsw & 0xFFFF);
+}
+
+function bit_rol(num, cnt)
+{
+  return (num << cnt) | (num >>> (32 - cnt));
+}
+
 function sha1_ft(t, b, c, d)
 {
   if(t < 20) return (b & c) | ((~b) & d);
@@ -154,32 +144,10 @@ function sha1_ft(t, b, c, d)
   return b ^ c ^ d;
 }
 
-/*
- * Determine the appropriate additive constant for the current iteration
- */
 function sha1_kt(t)
 {
   return (t < 20) ?  1518500249 : (t < 40) ?  1859775393 :
          (t < 60) ? -1894007588 : -899497514;
-}
-
-/*
- * Add integers, wrapping at 2^32. This uses 16-bit operations internally
- * to work around bugs in some JS interpreters.
- */
-function safe_add(x, y)
-{
-  var lsw = (x & 0xFFFF) + (y & 0xFFFF);
-  var msw = (x >> 16) + (y >> 16) + (lsw >> 16);
-  return (msw << 16) | (lsw & 0xFFFF);
-}
-
-/*
- * Bitwise rotate a 32-bit number to the left.
- */
-function bit_rol(num, cnt)
-{
-  return (num << cnt) | (num >>> (32 - cnt));
 }
 
 export default function hex_sha1(s) { return rstr2hex(rstr_sha1(str2rstr_utf8(s))); }


### PR DESCRIPTION
Updated Javascript for computing SHA1 hash that works for IE11 as
well as other modern browsers. Not tested against older versions of
IE.