### PR TITLE
Fix cleaning of item object

### DIFF
--- a/src/ds-client.js
+++ b/src/ds-client.js
@@ -105,6 +105,20 @@ export class DiscoveryService {
         });
     }
 
+    clean_item(item) {
+        if (item.entity && (item.entity.entity_id || item.entity.entityID) && item.entity.title) {
+            var entity = item.entity;
+            if (entity && entity.entityID && !entity.entity_id) {
+               entity.entity_id = entity.entityID;
+            }
+            if (entity && !entity.entity_icon && entity.icon) {
+               entity.entity_icon = entity.icon;
+            }
+        }
+        
+        return item;
+    }
+
     with_items(callback) {
         var obj = this;
         var storage = this.get_storage();
@@ -121,18 +135,10 @@ export class DiscoveryService {
                 lst = [];
             }
 
-            var clean = {};
+            var cleaned_items = {};
             for (var i = 0; i < lst.length; i++) {
-                if (lst[i].entity && (lst[i].entity.entity_id || lst[i].entity.entityID) && lst[i].entity.title) {
-                    var entity = lst[i].entity;
-                    if (entity && entity.entityID && !entity.entity_id) {
-                       entity.entity_id = entity.entityID;
-                    }
-                    if (entity && !entity.entity_icon && entity.icon) {
-                       entity.entity_icon = entity.icon;
-                    }
-                    clean[entity.entity_id] = lst[i];
-                }
+                var cleaned_item = this.clean_item(lst[i]);
+                cleaned_items[cleaned_item.entity['entity_id']] = cleaned_item;
             }
 
             lst = Object.values(clean);
@@ -159,6 +165,7 @@ export class DiscoveryService {
                     return obj.json_mdq_get(id).then(function(entity) {
                         if (entity) {
                             item.entity = entity;
+                            item = this.clean_item(item);
                             item.last_refresh = now;
                         }
                         return item;


### PR DESCRIPTION
The item object passed around includes an entity property, and that
entity property is itself an object that some templates expect to
contain properties entity_id and entity_icon. This commit moves code for
cleaning the item and making sure there are properties entity_id and
entity_icon into a function.

It also applies that function in the logic branch executed when the
cache_time has expired. This fixes an issue where templates
expect entity_id and entity_icon and when they are not present due to
the cache expiring the discovery service stops working.