### PR TITLE
Call after function with number rendered after remove

### DIFF
--- a/src/jquery-ds-widget.js
+++ b/src/jquery-ds-widget.js
@@ -145,6 +145,7 @@ jQuery(function ($) {
             $('body').on('click', 'div.remove', function (e) {
                 e.stopPropagation();
                 var entity_element = $(this).closest(obj.selection_selector);
+                obj._count = entity_element.siblings().length + 1;
                 var entity_id = entity_element.attr('data-href');
                 if (entity_id) {
                     obj._ds.remove(entity_id).then(function () {


### PR DESCRIPTION
Fix so that when clicking to remove a rendered element or entity
the correct number of entities rendered is passed to the _after()
function, which then passes the correct number to the defined (if any)
after() function. Without this change the _after() function is always
passed -1 and therefore after() is always passed -1.