### PR TITLE
Strip left-hand side of query text with email address

### DIFF
--- a/src/jquery-ds-widget.js
+++ b/src/jquery-ds-widget.js
@@ -116,6 +116,11 @@ jQuery(function ($) {
                         return obj.options['too_many_results'](data.length);
                     },
                     sourceData: function (text, callback) {
+                        let i = text.indexOf('@');
+                        if (i > -1) {
+                            text = text.substring(i+1, text.length);
+                        }
+
                         let remote = search_base + "?query=" + text;
 
                         if (search_related) {


### PR DESCRIPTION
If the query text contains an email address strip the left-hand side and
only send the domain as query text to the backend.