### PR TITLE
Better Makefile PATH to support non-global npm modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ VERSION:=1.0.1
 NAME:=thiss-js
 REGISTRY:=docker.sunet.se
 
+export PATH := node_modules/.bin:$(PATH)
+
 all: standalone
 
 snyk:


### PR DESCRIPTION
Add an export directive in the Makefile to add node_modules/.bin to the
PATH so that webpack can be found when it is not installed globally.