### PR TITLE
Add sameserver build option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ build: test snyk
 standalone:
 	make BASE_URL='$$$${BASE_URL}' COMPONENT_URL='$$$${BASE_URL}/cta/' MDQ_URL='$$$${MDQ_URL}' PERSISTENCE_URL='$$$${BASE_URL}/ps/' SEARCH_URL='$$$${SEARCH_URL}' STORAGE_DOMAIN='$$$${STORAGE_DOMAIN}' LOGLEVEL='$$$${LOGLEVEL}' DEFAULT_CONTEXT='$$$${DEFAULT_CONTEXT}' build
 
+sameserver:
+	make BASE_URL='/' COMPONENT_URL='/cta/' MDQ_URL='/entities/' PERSISTENCE_URL='/ps/' SEARCH_URL='/api/search' STORAGE_DOMAIN='/' LOGLEVEL='error' DEFAULT_CONTEXT='thiss.io' build
+
 tests:
 	@npm run test
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -10,6 +10,7 @@ The included Makefile has a number of targets aimed at those who want to build a
 * ``make local``: Runs a local development instance for a local pyFF instance running on port 8000
 * ``make build``: Builds the instance running on thiss.io in the dist directory
 * ``make standalone``: Builds a standalone instance used in the docker container (with envsubst) in the dist directory
+* ``make sameserver``: Builds a lightweight host agnostic replacement for the deprecated embedded pyFF DS when pyFF is running on the same server
 * ``make docker``: Builds a docker container (thiss-js:<version>) based on ``standalone`` and nginx
 
 Running docker


### PR DESCRIPTION
As discussed during NTW2019 this introduces a lightweight HOST agnostic "sameserver" build option in the case one only needs a DS replacement for the deprecated pyFF embedded DS.