### PR TITLE
Align Docker documentation with current pyFF endpoint behavior

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -52,8 +52,8 @@ In order to run your own instance of thiss-js you need a search-capable MDQ serv
 .. code-block:: bash
 
   # docker run -ti -p 9000:80 \
-        -e MDQ_URL=http://mdq:8080/entities \
-        -e SEARCH_URL=http://mdq:8080/entities \
+        -e MDQ_URL=http://mdq:8080/entities/ \
+        -e SEARCH_URL=http://mdq:8080/entities/ \
         -e BASE_URL=http://localhost:9000/ \
         -e STORAGE_DOMAIN="example.com" \
         thiss-js:1.0.0


### PR DESCRIPTION
Patch to align the Docker documentation with the current pyFF endpoint
behavior. The MDQ_URL needs to end with entities\ (note the slash). If
it does not then pyFF currently will return metadata for all entities
instead of the metadata for the single entity the user wants to use for
authentication. I also added a slash for SEARCH_URL for consistency
(tested and it works).