### PR TITLE
Added simple progressive scrolling to long list of results.

### DIFF
--- a/src/ds/ds-widget.js
+++ b/src/ds/ds-widget.js
@@ -1,14 +1,5 @@
 import {DiscoveryService, json_mdq_search, parse_qs} from "@theidentityselector/thiss-ds";
 
-function render_results(results, counter, render) {
-    for (let data in results) {
-        counter += 1;
-        data.counter = counter;
-        data.saved = false;
-        render(data)
-    }
-}
-
 jQuery(function ($) {
     $.widget("thiss.discovery_client", {
 
@@ -120,13 +111,35 @@ jQuery(function ($) {
                         } else if (opts.maxResults > 0 && results.length > opts.maxResults) {
                             render(obj.options.too_many_results(this, results.length))
                         } else {
-                            for (let i in results) {
-                                let data = results[i]
-                                counter += 1;
-                                data.counter = counter;
-                                data.saved = false;
-                                render(obj.options.render_search_result(data))
+                            const getResults = function() {
+                                const numberDisplayed = $(obj.options.search_result_selector + " > *").length
+
+                                if (numberDisplayed === 0) {
+                                    return results.slice(0, 24)
+                                } else {
+                                    return results.slice(numberDisplayed, numberDisplayed + 25)
+                                }
                             }
+
+                            const displayResults = function() {
+                                const resultsSubset = getResults()
+
+                                for (let i in resultsSubset) {
+                                    let data = resultsSubset[i]
+                                    counter += 1;
+                                    data.counter = counter;
+                                    data.saved = false;
+                                    render(obj.options.render_search_result(data))
+                                }
+                            }
+
+                            displayResults();
+
+                            window.onscroll = function(ev) {
+                                if ($(window).scrollTop() + $(window).height() === $(document).height()) {
+                                    displayResults();
+                                }
+                            };
                         }
                     },
                     sourceData: obj.options.search,


### PR DESCRIPTION
Upon searching for an institution, when the list of results is long, the user sees the "Show me anyway" message and link that displays all results--no matter how long the list is. This PR introduces simple progressive scrolling. Upon clicking the "Show me anyway" link, user will see 25 results, once the user scrolls to the bottom, 25 more...and so on.

Additionally render_results() function was removed as it's redundant.