### PR TITLE
Added correct shade of blue, replaced outline.

### DIFF
--- a/src/assets/cta.scss
+++ b/src/assets/cta.scss
@@ -6,12 +6,17 @@ body {
 
 button {
   &.ra21-button {
-    background-color: var(--primary-blue);
+    background-color: var(--pastel-blue);
     color: var(--white);
     border-radius: 5px;
     width: 100%;
     padding: 0;
     border: none;
+  }
+
+  &.ra21-button:focus {
+    outline: none;
+    box-shadow: inset 0 0 0 1pt var(--primary-blue);
   }
 
   .ra21-button  {
@@ -67,7 +72,12 @@ a {
     /* Zep */
     font-size: 13px;
     line-height: 1.46;
-    color: var(--primary-blue);
+    color: var(--pastel-blue);
+  }
+
+  &.ra21-access-text:focus {
+    outline: none;
+    text-decoration: underline;
   }
 
   &.ra21-access-text:hover {

--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -48,6 +48,7 @@
   --text-grey: #444444;
   --warm-grey: #767676;
   --footer-grey: #ebebeb;
+  --pastel-blue: #216e93;
   --primary-blue: #0079ff;
   --secondary-blue: #0056b3;
   --white-50: rgba(255, 255, 255, 0.5);

--- a/src/component.js
+++ b/src/component.js
@@ -10,7 +10,7 @@ import {toCSS, destroyElement} from 'belter/src';
 
 function _set_default_props(opts) {
     if (opts.props.color === undefined) {
-        opts.props.color = "#0079ff";
+        opts.props.color = "#216e93";
     }
     if (opts.props.backgroundColor === undefined) {
         opts.props.backgroundColor = "#FFFFFF";


### PR DESCRIPTION
Added "pastel-blue" which is the correct shade of blue for the button. This means that component.js had to be updated to add default blue. In addition, the default browser outline around the button had to be changed to accommodate for the width constraint presented by an IFrame. Outline was replaced with a box-shadow that is "inset" in the button to avoid IFrame/button width manipulation. The "focus" state on the link below is simply set to "underline".