### PR TITLE
Removed popper NPM package from packages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "mocker-api": "^1.6.7",
     "node-sass": "^4.14.1",
     "nyc": "^13.3.0",
-    "popper": "^1.0.1",
     "preload-webpack-plugin": "^3.0.0-beta.3",
     "raw-loader": "^1.0.0",
     "rebuild-node-sass": "^1.1.0",


### PR DESCRIPTION
Package is redunant and outdated. Removing it fixes a timeout during a brand new build.