### PR TITLE
Add translations for South African languages

### DIFF
--- a/src/assets/translations/af.json
+++ b/src/assets/translations/af.json
@@ -1,0 +1,34 @@
+{
+  "@metadata": {
+    "authors": [
+      "TENET",
+      "ST Communications"
+    ],
+    "last-updated": "2022-07-17",
+    "locale": "af"
+  },
+  "cta-button-placeholder": "Kry toegang deur jou instelling",
+  "cta-button-header": "Kry toegang deur",
+  "cta-link": "Voeg instelling by of verwyder",
+  "ds-header": "Toegang tot",
+  "ds-footer-about-us": "Meer omtrent ons",
+  "ds-search-heading": "Vind jou instelling",
+  "ds-search-subheading": "Jou universiteit, organisasie of maatskappy",
+  "ds-search-example": "Voorbeelde: Science Institute, Lee@uni.edu, UCLA",
+  "ds-search-placeholder": "Soek tans vir instellings …",
+  "ds-choose-heading": "Kies jou instelling",
+  "ds-choose-subheading": "Onlangse instellings",
+  "ds-choose-add-another": "Voeg ’n ander instelling by",
+  "ds-edit-heading": "Redigeer instellings",
+  "ds-edit-subheading": "As jy nie langer wil hê dat ’n instelling op hierdie toestel onthou word nie, verwyder dit van die lys hier onder.",
+  "ds-choose-edit": "Redigeer  ",
+  "ds-choose-done": "Klaar",
+  "ds-notice-and-consent-remember": "Onthou hierdie keuse",
+  "ds-notice-and-consent-learn-more": "Vind meer uit",
+  "ds-notice-and-consent-banner-storage-info": "Die instelling wat jy kies sal in hierdie blaaier se plaaslike berging gebêre word en sal beskikbaar gemaak word aan hierdie werf en ander werwe wat SeamlessAccess gebruik. Jy kan enige tyd jou blaaier se plaaslike berging skoonmaak.",
+  "ds-notice-and-consent-banner-more-info": "Bykomende privaatheidsinligting",
+  "ds-notice-and-consent-banner-personal-info": "Geen aanmeld-, e-pos- of persoonlike inligting word gebêre nie.",
+  "ds-too-many-result-show": "Wys my in elk geval alle passings",
+  "ds-too-many-result-matches": "Passings",
+  "ds-too-many-result-keep-typing": "hou aan tik om jou soektog te verfyn"
+}

--- a/src/assets/translations/st.json
+++ b/src/assets/translations/st.json
@@ -1,0 +1,34 @@
+{
+  "@metadata": {
+    "authors": [
+      "TENET",
+      "ST Communications"
+    ],
+    "last-updated": "2022-07-17",
+    "locale": "st"
+  },
+  "cta-button-placeholder": "Ho kena ka mokgatlo wa hao",
+  "cta-button-header": "Ho kena ka",
+  "cta-link": "Kenya kapa fetola mokgatlo",
+  "ds-header": "Ho kena",
+  "ds-footer-about-us": "Mabapi le Rona",
+  "ds-search-heading": "Fumana Mokgatlo wa Hao",
+  "ds-search-subheading": "Yunivesiti ya hao, mokgatlo kapa khampani",
+  "ds-search-example": "Mehlala: Mokgatlo wa saense, Lee@uni.edu, UCLA",
+  "ds-search-placeholder": "Ho batla mekgatlo...",
+  "ds-choose-heading": "Kgetha Mokgatlo wa Hao",
+  "ds-choose-subheading": "Mekgatlo ya moraorao",
+  "ds-choose-add-another": "Kenya mokgatlo o mong",
+  "ds-edit-heading": "Etsa tokiso mekgatlong",
+  "ds-edit-subheading": "Haeba ha o sa batle hore mokgatlo o hopolwe divaeseng ena, o tlose lethathamong le ka tlase.",
+  "ds-choose-edit": "Lokisa",
+  "ds-choose-done": "O qetile",
+  "ds-notice-and-consent-remember": "Hopola kgetho ena",
+  "ds-notice-and-consent-learn-more": "Ithute Haholwanyane",
+  "ds-notice-and-consent-banner-storage-info": "Mokgatlo oo o o kgethang o tla bolokwa polokelong ya boraosara ena mme e tla fumaneha ditsing tsena le tse ding tse sebedisang SeamlessAccess. O ka nna wa tlosa dintho tse leng polokelong ya boraosara ena neng kapa neng.",
+  "ds-notice-and-consent-banner-more-info": "Tlhahisoleseding e Eketsehileng ya Lekunutu",
+  "ds-notice-and-consent-banner-personal-info": "Ha ho na tlhahisoleseding ya ho kena, ya imeili kapa ya botho e tla bolokwa",
+  "ds-too-many-result-show": "Ho ntse ho le jwalo mpontshe yohle e nyallanang",
+  "ds-too-many-result-matches": "E nyallanang",
+  "ds-too-many-result-keep-typing": "tswela pele o ntse o thaepa ho ntlafatsa tsela ya hao ya ho batla"
+}

--- a/src/assets/translations/xh.json
+++ b/src/assets/translations/xh.json
@@ -1,0 +1,34 @@
+{
+  "@metadata": {
+    "authors": [
+      "TENET",
+      "ST Communications"
+    ],
+    "last-updated": "2022-07-17",
+    "locale": "xh"
+  },
+  "cta-button-placeholder": "Fikelela usebenzisa iziko lakho",
+  "cta-button-header": "Fikelela usebenzisa",
+  "cta-link": "Yongeza okanye utshintshe iziko",
+  "ds-header": "Ufikelelo kwi",
+  "ds-footer-about-us": "Malunga Nathi",
+  "ds-search-heading": "Fumana Iziko Lakho",
+  "ds-search-subheading": "Iyunivesithi, iziko okanye inkampani yakho",
+  "ds-search-example": "Imizekelo: Iziko Lesayensi, Lee@uni.edu, UCLA",
+  "ds-search-placeholder": "Ikhangela amaziko...",
+  "ds-choose-heading": "Khetha Iziko Lakho",
+  "ds-choose-subheading": "Amaziko akutshanje",
+  "ds-choose-add-another": "Yongeza elinye iziko",
+  "ds-edit-heading": "Hlela amaziko",
+  "ds-edit-subheading": "Ukuba awusafuni iziko likhunjulwe kule divayisi, lisuse kuluhlu olungezantsi.",
+  "ds-choose-edit": "Hlela",
+  "ds-choose-done": "Igqibile",
+  "ds-notice-and-consent-remember": "Khumbula olu khetho",
+  "ds-notice-and-consent-learn-more": "Funda Ngakumbi",
+  "ds-notice-and-consent-banner-storage-info": "Iziko olikhethayo liza kugcinwa kugcino lwangaphakathi lwale bhrawuza yaye luza kwenziwa lufumaneke kule nakwezinye iisayithi ezisebenzisa i-SeamlessAccess. Kufuneka ucime izinto ezikugcino lwangaphakathi lwebhrawuza yakho nanini na.",
+  "ds-notice-and-consent-banner-more-info": "Inkcazelo Yemfihlelo Eyongezelelekileyo",
+  "ds-notice-and-consent-banner-personal-info": "Akukho nkcazelo yokungena, yeimeyile okanye yobuqu igciniweyo.",
+  "ds-too-many-result-show": "Ndibonise zonke ezifanayo sekunjalo",
+  "ds-too-many-result-matches": "Ezifanayo",
+  "ds-too-many-result-keep-typing": "qhubeka utayipa ukuze ulungise ukhangelo lwakho"
+}

--- a/src/assets/translations/zu.json
+++ b/src/assets/translations/zu.json
@@ -1,0 +1,34 @@
+{
+  "@metadata": {
+    "authors": [
+      "TENET",
+      "ST Communications"
+    ],
+    "last-updated": "2022-07-17",
+    "locale": "zu"
+  },
+  "cta-button-placeholder": "Finyelela ngesikhungo sakho",
+  "cta-button-header": "Ukufinyelela usebenzisa",
+  "cta-link": "Engeza noma shintsha isikhungo",
+  "ds-header": "Ukufinyelela kokuthi",
+  "ds-footer-about-us": "Mayelana Nathi",
+  "ds-search-heading": "Thola Isikhungo Sakho",
+  "ds-search-subheading": "Inyuvesi yakho, inhlangano noma inkampani",
+  "ds-search-example": "Izibonelo: Isikhungo Sesayensi, Lee@uni.edu, UCLA",
+  "ds-search-placeholder": "Isesha izikhungo...",
+  "ds-choose-heading": "Khetha Isikhungo Sakho",
+  "ds-choose-subheading": "Izikhungo Zakamuva",
+  "ds-choose-add-another": "Engeza esinye isikhungo",
+  "ds-edit-heading": "Hlela izikhungo",
+  "ds-edit-subheading": "Uma ungasafuni ukuthi izikhungo zikhunjulwe kule divayisi, sisuse ohlwini olungezansi.",
+  "ds-choose-edit": "Hlela",
+  "ds-choose-done": "Iqedile",
+  "ds-notice-and-consent-remember": "Khumbula lokhu kukhetha",
+  "ds-notice-and-consent-learn-more": "Funda Kabanzi",
+  "ds-notice-and-consent-banner-storage-info": "Isikhungo ozama ukusikhetha sizolondolozwa  kusitoreji sasendaweni sale bhrawuza futhi sizokwenziwa sitholakale kule sayithi kanye namanye asebenzisa Ukufinyelela Okulula. Ungakwazi ukusula isitoreji sasendaweni sebhrawuza yakho nganom yisiphi isikhathi.",
+  "ds-notice-and-consent-banner-more-info": "Ulwazi Lobumfihlo Olwengeziwe",
+  "ds-notice-and-consent-banner-personal-info": "Akukho ukungena ngemvume, i-imeyili noma ulwazi lomuntu siqu olugcinwayo.",
+  "ds-too-many-result-show": "Ngibonise konke okufanayo noma kunjalo",
+  "ds-too-many-result-matches": "Okufanayo",
+  "ds-too-many-result-keep-typing": "qhubeka uthayipha ukuze ucwengisise usesho lwakho"
+}

--- a/src/ds/index.html
+++ b/src/ds/index.html
@@ -78,7 +78,12 @@
 				<a href="https://seamlessaccess.org/about/" data-i18n="ds-footer-about-us">About Us</a>
 				<select name="locale-selector" id="locale-selector" class="ml-4">
 					<option value="en">English</option>
+					<option value="af">Afrikaans</option>
 					<option value="es">Español</option>
+					<option value="xh">isiXhosa</option>
+					<option value="st">Sesotho</option>
+					<option value="sv">Svenska</option>
+					<option value="zu">Zulu</option>
 				</select>
 			</p>
 		</div>


### PR DESCRIPTION
This adds four new translations for four of the most widely spoken South African languages: Afrikaans, Sesotho, isiXhosa, and Zulu. They span two major language families (Nguni & Sotho-Tswana) with a high degree of mutual intelligibility, so hopefully provide basic coverage for more languages than the translations themselves.

The translations are the work of a professional translation house that specialises in software localisation. We periodically contract the translation of portions of software we widely use in the SAFIRE identity federation, particularly those that are end-user facing. These got done as part of the last round.