### PR TITLE
Update start.sh

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -56,7 +56,7 @@ cat>>/etc/nginx/nginx.conf<<EOF
       location / {
          try_files \$uri \$uri/index.html \$uri/ =404;
          absolute_redirect off;
-         location ~*  \.(jpg|jpeg|png|gif|svg|ico|html|json|css|js|eot|ttf|woff|woff2)$ {
+         location ~*  \.(jpg|jpeg|png|gif|svg|ico|html|css|js|eot|ttf|woff|woff2)$ {
             sendfile on;
             tcp_nopush on;
             tcp_nodelay on;


### PR DESCRIPTION
If `json` is included, that means requests for a entities' discovery JSON (e.g. `entities/%7Bsha1%7Dd6cad1541a6653fa308955d7341b7171bc970f09.json`) won't be proxied, but handled by `Location /`.