### PR TITLE
Change primary blue to WCAG AAA valid color

### DIFF
--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -51,7 +51,7 @@
   --warm-grey: #767676;
   --footer-grey: #ebebeb;
   --pastel-blue: #216e93;
-  --primary-blue: #0079ff;
+  --primary-blue: #1465DB;
   --secondary-blue: #0056b3;
   --dark-blue: #0c1c27;
   --white-50: rgba(255, 255, 255, 0.5);


### PR DESCRIPTION
We currently use a primary blue that is not valid for WCAG, with a small shade change we can make it valid.

Fixes https://github.com/TheIdentitySelector/thiss-js/issues/282 