### PR TITLE
Guard requestStorageAccess in getStorageHandle to avoid uncaught NotAllowedError

### DIFF
--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -734,10 +734,20 @@ export async function getStorageHandle() {
 
   // Check if access has already been granted
   if (await document.hasStorageAccess()) {
-    const handle = await document.requestStorageAccess({all: true});
-    if (handle) {
-      return handle;
-    } else {
+    try {
+      const handle = await document.requestStorageAccess({all: true});
+      if (handle) {
+        return handle;
+      } else {
+        return window;
+      }
+    } catch (error) {
+      // requestStorageAccess({all: true}) requires transient user activation;
+      // when hasStorageAccess() is already true (e.g. a same-origin/first-party
+      // frame) this runs at page load with no activation and rejects with
+      // NotAllowedError. The granted-permission branch below already guards the
+      // same call; without this guard the rejection is uncaught. Fall back to
+      // window, which is first-party storage in that case.
       return window;
     }
   }


### PR DESCRIPTION
### Problem

`getStorageHandle()` calls `document.requestStorageAccess({all: true})` inside the `hasStorageAccess() === true` branch without a try/catch:

```js
if (await document.hasStorageAccess()) {
  const handle = await document.requestStorageAccess({all: true});
  ...
}
```

`requestStorageAccess({all: true})` requires transient user activation. When `hasStorageAccess()` is already `true` — e.g. a same-origin / first-party persistence (`/ps/`) iframe on a discovery-service page — this runs at page load with no user gesture, so the promise rejects with `NotAllowedError: requestStorageAccess not allowed`. Unlike the `permission.state === 'granted'` branch below it, this branch has no try/catch, so the rejection is uncaught and surfaces in the console on every load.

### Fix

Wrap the call in try/catch and fall back to `window`, mirroring the already-guarded `granted` branch. For a same-origin frame `window` is first-party storage, so the fallback is correct.

### Testing

Built and ran the container, loaded the discovery service in Chrome/Brave: the uncaught `NotAllowedError` at page load is gone, and the persistence iframe/checkbox still work.
